### PR TITLE
Low to zero probability of joint (or conditional) firing for a given pair of neurons

### DIFF
--- a/Est_Data.py
+++ b/Est_Data.py
@@ -127,7 +127,8 @@ for i in range(0, n):
 #remove J file
 
 # debug
-# cmd = ['rm', "J_py_"+str(T)+".txt"]
-# proc.check_call(cmd)
-os.remove("J_py_"+str(T)+".txt")
-
+if os.name is 'nt':
+    os.remove("J_py_"+str(T)+".txt")
+else:
+    cmd = ['rm', "J_py_"+str(T)+".txt"]
+    proc.check_call(cmd)

--- a/Est_Data.py
+++ b/Est_Data.py
@@ -13,6 +13,7 @@ example command : python3 Est_Data.py simulation_data 20 sim
 from glmcc import *
 import sys
 import subprocess as proc
+import os
 
 args = sys.argv
 
@@ -126,6 +127,7 @@ for i in range(0, n):
 #remove J file
 
 # debug
-cmd = ['rm', "J_py_"+str(T)+".txt"]
-proc.check_call(cmd)
+# cmd = ['rm', "J_py_"+str(T)+".txt"]
+# proc.check_call(cmd)
+os.remove("J_py_"+str(T)+".txt")
 

--- a/Est_Data.py
+++ b/Est_Data.py
@@ -42,33 +42,20 @@ for i in range(0, DataNum):
 
         #set tau
         tau = [4, 4]
-#<<<<<<< master
-#        beta = 4000
-#        corr_flag = True
-#=======
 
-#>>>>>>> master
         #Fitting a GLM
         if mode == 'sim':
             delay_synapse = 3
             par, log_pos, log_likelihood = GLMCC(cc_list[1], cc_list[0], tau, beta, cc_list[2], cc_list[3], delay_synapse)
         elif mode == 'exp':
             log_pos = 0
-#<<<<<<< master
-#            for m in range(2, 5):
-#                try:
-                    tmp_par, tmp_log_pos = GLMCC(cc_list[1], cc_list[0], tau, beta, cc_list[2], cc_list[3], m)
-#                except:
-#                    print("cc_list empty, no joint spikes")
-#                    corr_flag = False
-#                    continue
-#                if m == 2 or tmp_log_pos > log_pos:
-#=======
+            tmp_par, tmp_log_pos = GLMCC(cc_list[1], cc_list[0], tau, beta, cc_list[2], cc_list[3], m)
+
             log_likelihood = 0
             for m in range(1, 5):
                 tmp_par, tmp_log_pos, tmp_log_likelihood = GLMCC(cc_list[1], cc_list[0], tau, beta, cc_list[2], cc_list[3], m)
                 if m == 1 or (not LR and tmp_log_pos > log_pos) or (LR and tmp_log_likelihood > log_likelihood):
-#>>>>>>> master
+
                     log_pos = tmp_log_pos
                     log_likelihood = tmp_log_likelihood
                     par = tmp_par

--- a/Est_Data.py
+++ b/Est_Data.py
@@ -37,7 +37,7 @@ for i in range(0, DataNum):
         #set tau
         tau = [4, 4]
         beta = 4000
-
+        corr_flag = True
         #Fitting a GLM
         if mode == 'sim':
             delay_synapse = 3
@@ -45,7 +45,12 @@ for i in range(0, DataNum):
         elif mode == 'exp':
             log_pos = 0
             for m in range(2, 5):
-                tmp_par, tmp_log_pos = GLMCC(cc_list[1], cc_list[0], tau, beta, cc_list[2], cc_list[3], m)
+                try:
+                    tmp_par, tmp_log_pos = GLMCC(cc_list[1], cc_list[0], tau, beta, cc_list[2], cc_list[3], m)
+                except:
+                    print("cc_list empty, no joint spikes")
+                    corr_flag = False
+                    continue
                 if m == 2 or tmp_log_pos > log_pos:
                     log_pos = tmp_log_pos
                     par = tmp_par
@@ -65,16 +70,16 @@ for i in range(0, DataNum):
             cc_0[l] = 0
             max[l] = int(tau[l] + 0.1)
             
-            if l == 0:
+            if l == 0 and corr_flag:
                 for m in range(max[l]):
                     cc_0[l] += np.exp(par[nb+int(delay_synapse)+m])
-            if l == 1:
+            if l == 1 and corr_flag:
                 for m in range(max[l]):
                     cc_0[l] += np.exp(par[nb-int(delay_synapse)-m])
 
             cc_0[l] = cc_0[l]/max[l]
-                    
-            Jmin[l] = math.sqrt(16.3/ tau[l]/ cc_0[l])
+            if corr_flag:
+                Jmin[l] = math.sqrt(16.3/ tau[l]/ cc_0[l])
             n12 = tau[l]*cc_0[l]
             if n12 <= 10:
                 par[NPAR-2+l] = 0


### PR DESCRIPTION
Before, the algorithm was crashing giving me such a message.
<img width="429" alt="Kobayashi error" src="https://user-images.githubusercontent.com/12449152/114556662-37681800-9c69-11eb-9202-13e606b5afbc.png">

I saw that for these pair, the cross-correlation was completely empty. From my naive viewpoint, I thought that assigning a 0 weight to this connection could be a way to cope with these situations solely by skipping the estimation. Now the output of the command looks something like this.

![KobayashiOUt](https://user-images.githubusercontent.com/12449152/114557543-12c07000-9c6a-11eb-9592-790f2832052e.png)

I hope that this doesn't interfere with the normal calculations for which the algorithm was designed for.

Best regards
Emilio Isaías-Camacho